### PR TITLE
one record per transaction

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -25,7 +25,7 @@ enum FastUsdcTransactionStatus {
 }
 
 type FastUsdcTransaction @entity {
-  id: ID!
+  id: ID! @index(unique: true)
   """
   EVM address from which the USCD funds originated
   """

--- a/src/mappings/events/fastUsdc.ts
+++ b/src/mappings/events/fastUsdc.ts
@@ -21,6 +21,8 @@ export const transactionEventKit = (block: CosmosBlock, data: StreamCell, module
     const { height } = block.header;
     const time = block.header.time as Date;
 
+    // XXX this assumes that records will be processed in order,
+    // so multiple indexer workers is not supported.
     const t = await FastUsdcTransaction.get(id);
     if (!t) {
       if (payload.status !== FastUsdcTransactionStatus.OBSERVED) {


### PR DESCRIPTION
fixes #3 

I'm not certain but I suspect the reason we had multiple rows for the transaction was that it ran in multiple worker jobs, creating a race between the `get` and `create` calls.

This adds a unique index on the field to prevent duplicates for the same transaction ID and adds a note about multiple workers.

I won't reindex now because the system is working fine but when we do reindex this will ensure there is one record per transaction.